### PR TITLE
Compatible with acceleration urls

### DIFF
--- a/denops/@dpp-protocols/git.ts
+++ b/denops/@dpp-protocols/git.ts
@@ -77,7 +77,7 @@ export class Protocol extends BaseProtocol<Params> {
     }
 
     const directory = url.replace(/\.git$/, "").replace(/^https:\/+|^git@/, "")
-      .replace(/:/, "/");
+      .replace(/\/htpps:\/+/, "/").replace(/:/, "/");
 
     return {
       path: `${await vars.g.get(


### PR DESCRIPTION
In China, due to network issues, users have to use acceleration sites, such as gitclone.com. However, acceleration sites are not mirror sites, and their usage is slightly different. For example, if I need to download dpp.vim from gitclone.com, I have to use the following command: git clone https://gitclone.com/https://github.com/Shougo/dpp.vim.git

This results in the final folder path becoming:
gitclone.com/https///github.com/Shougo/dpp.vim

This patch is intended to accommodate this situation, ultimately generating:

gitclone.com/github.com/Shougo/dpp.vim